### PR TITLE
remove dependency on plugin.program.autocomlplete

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.autocompletion" name="AutoCompletion library" version="2.1.1" provider-name="Philipp Temminghoff (phil65), bbaronSVK, finkleandeinhorn, berkhornet">
+<addon id="script.module.autocompletion" name="AutoCompletion library" version="2.1.2" provider-name="Philipp Temminghoff (phil65), bbaronSVK, finkleandeinhorn, berkhornet">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" version="2.9.1"/>

--- a/lib/AutoCompletion.py
+++ b/lib/AutoCompletion.py
@@ -18,8 +18,11 @@ import xbmcvfs
 SCRIPT_ID = "script.module.autocompletion"
 SCRIPT_ADDON = xbmcaddon.Addon(SCRIPT_ID)
 PLUGIN_ID = "plugin.program.autocompletion"
-PLUGIN_ADDON = xbmcaddon.Addon(PLUGIN_ID)
-SETTING = PLUGIN_ADDON.getSetting
+try:
+    PLUGIN_ADDON = xbmcaddon.Addon(PLUGIN_ID)
+    SETTING = PLUGIN_ADDON.getSetting
+except RuntimeError:
+    SETTING = SCRIPT_ADDON.getSetting
 ADDON_PATH = xbmcvfs.translatePath(SCRIPT_ADDON.getAddonInfo("path"))
 ADDON_ID = SCRIPT_ADDON.getAddonInfo("id")
 ADDON_DATA_PATH = xbmcvfs.translatePath(SCRIPT_ADDON.getAddonInfo("profile"))


### PR DESCRIPTION
Version 2.1.1 of this script introduces an implied dependency on plugin.program.autocompletion

This results in it not being backwards compatible when script.module.autocompletion is used in other scripts as a dependency -- it creates an exception in Kodi when plugin.program.autocompletion is not installed.

This PR restores compatibility by wrapping the calls to plugin.program.autocompletion in a try/except block.  If plugin.program.autocompletion is not installed/enabled the except will fall back to running as it did in ver 2.0.6 and prior.

Tested in an addon which uses script.module.kutils which in turn has dependency on scritp.module.autocompletion.